### PR TITLE
fix: decidePolicyForNavigationAction 수정

### DIFF
--- a/src/ios/CDVThemeableBrowser.m
+++ b/src/ios/CDVThemeableBrowser.m
@@ -1509,18 +1509,18 @@
 //    return [self.navigationDelegate webViewDidStartLoad:theWebView];
 //}
 
-// - (BOOL)webView:(WKWebView*)theWebView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType
-// {
+//- (BOOL)webView:(WKWebView*)theWebView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType
+//{
 //    BOOL isTopLevelNavigation = [request.URL isEqual:[request mainDocumentURL]];
-
+//
 //    if (isTopLevelNavigation) {
 //        self.currentURL = request.URL;
 //    }
-
+//
 //    [self updateButtonDelayed:theWebView];
-
+//
 //    return [self.navigationDelegate webView:theWebView shouldStartLoadWithRequest:request navigationType:navigationType];
-// }
+//}
 
 //- (void)webViewDidFinishLoad:(UIWebView*)theWebView
 //{

--- a/src/ios/CDVThemeableBrowser.m
+++ b/src/ios/CDVThemeableBrowser.m
@@ -559,14 +559,41 @@
 
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-    
     NSURLRequest *request = navigationAction.request;
-    if ([self isSystemUrl:request.URL] || navigationAction.targetFrame == nil) {
-        [[UIApplication sharedApplication] openURL:request.URL];
+    NSURL* url = request.URL;
+    NSURL* mainDocumentURL = request.mainDocumentURL;
+    BOOL isTopLevelNavigation = [url isEqual:mainDocumentURL];
+    BOOL shouldStart = YES;
+    
+    // if is an app store link, let the system handle it, otherwise it fails to load it
+    NSArray * allowedSchemes = @[@"itms-appss", @"itms-apps", @"tel", @"sms", @"mailto", @"geo"];
+    if ([allowedSchemes containsObject:[url scheme]]) {
+        [webView stopLoading];
+        [self openInSystem:url];
+        shouldStart = NO;
+    }
+    else if ((self.callbackId != nil) && isTopLevelNavigation) {
+        self.themeableBrowserViewController.currentURL = url;
+        // Send a loadstart event for each top-level navigation (includes redirects).
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                      messageAsDictionary:@{@"type":@"loadstart", @"url":[url absoluteString]}];
+        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+        
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    }
+    
+    if(shouldStart){
+        // Fix GH-417 & GH-424: Handle non-default target attribute
+        // Based on https://stackoverflow.com/a/25713070/777265
+        if (!navigationAction.targetFrame){
+            [webView loadRequest:navigationAction.request];
+            decisionHandler(WKNavigationActionPolicyCancel);
+        }else{
+            originalUrl = url;
+            decisionHandler(WKNavigationActionPolicyAllow);
+        }
+    }else{
         decisionHandler(WKNavigationActionPolicyCancel);
-    } else {
-        self.themeableBrowserViewController.currentURL = request.URL;
-        decisionHandler(WKNavigationActionPolicyAllow);
     }
 }
 
@@ -1482,18 +1509,18 @@
 //    return [self.navigationDelegate webViewDidStartLoad:theWebView];
 //}
 
-//- (BOOL)webView:(WKWebView*)theWebView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType
-//{
+// - (BOOL)webView:(WKWebView*)theWebView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType
+// {
 //    BOOL isTopLevelNavigation = [request.URL isEqual:[request mainDocumentURL]];
-//
+
 //    if (isTopLevelNavigation) {
 //        self.currentURL = request.URL;
 //    }
-//
+
 //    [self updateButtonDelayed:theWebView];
-//
+
 //    return [self.navigationDelegate webView:theWebView shouldStartLoadWithRequest:request navigationType:navigationType];
-//}
+// }
 
 //- (void)webViewDidFinishLoad:(UIWebView*)theWebView
 //{


### PR DESCRIPTION
### 이슈
- 상황: iOS themeable browser 에서 loadstart 이벤트 미동작 이슈 발생
- 원인: shouldStartLoadWithRequest 에 loadstart 관련 코드가 있는데 주석 처리되어 있음. cordova inappbrowser 와 동일하게 decidePolicyForNavigationAction 내에 loadstart 관련 코드 추가 함.
- PR 중요도 : 🟡 보통
- PR 기한: 1월 23일 (목)
- 배포예정일: 미정
- 링크: [DEVDEP-2699](https://zimssa.atlassian.net/browse/DEVDEP-2699?atlOrigin=eyJpIjoiMzQ2MWUxNTdlNmUxNGVhNDgxZmE0NjdlMGZiNzc0ODkiLCJwIjoiaiJ9)

### 작업내용
- CDVThemeableBrowser.m 파일 내 decidePolicyForNavigationAction 코드 CDVWKInAppBrowser.m 와 유사하게 변경 (loadstart 코드 추가)


[DEVDEP-2699]: https://zimssa.atlassian.net/browse/DEVDEP-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ